### PR TITLE
Fixed direct comparison when using Django filter

### DIFF
--- a/whctools/templates/whctools/list_acl_members.html
+++ b/whctools/templates/whctools/list_acl_members.html
@@ -41,7 +41,9 @@
                         <tbody>
                             {% for member in members %}
                             <tr class="whctools-main-row" data-member-id="{{ member.main.character_id }}">
-                                <td>{% if member.alts|length>0 %}<i class="alt-caret fa-solid fa-caret-right"></i>{% endif %}</td>
+                                {% with member.alts|length as alts_length %}
+                                    <td>{% if alts_length > 0 %}<i class="alt-caret fa-solid fa-caret-right"></i>{% endif %}</td>
+                                {% endwith %}
                                 <td><img src="{{ member.main.portrait_url }}" alt="{{ member.main.name }}"></td>
                                 <td>{{member.main.name}}</td>
                                 <td><i>Main</i></td>


### PR DESCRIPTION
Fix by using an intermediate 'with' variable.

If this length is needed more often, then it can be converted into a custom filter.

Fixes #37 