### PR TITLE
Force memberaudit updates when a character applies

### DIFF
--- a/whctools/templates/whctools/index.html
+++ b/whctools/templates/whctools/index.html
@@ -23,44 +23,48 @@
                                     <img src="{{ auth_char.portrait_url }}" class="media-object {% if not auth_char.is_shared%}whctools-image-disabled-class{% endif %}">
                                     </div>
                                     <div class="media-body">
-                                    <h4 class="media-heading">{{auth_char.char_name}}</h4>
-                                    {% if not auth_char.is_in_approved_alliance%}
-                                        <p class="whctools-warning"><i class="fa fas fa-exclamation-triangle"></i>
-                                            Character is not in IVY or IVY-A, and cannot apply.
-                                            {% comment %} TODO @@@ - remove hardcoded names here {% endcomment %}
-                                        </p>
+                                    <h4 class="media-heading" style="margin-top:5px; margin-bottom: 0px">{{auth_char.char_name}}</h4>
+                                        <span style="font-size: 80%;"> Corp: <i><b> {{ auth_char.corporation_name }}</b></i></span>
+                                        <span style="display:inline-block; min-width:5px"> </span>
+                                        <span style="font-size: 80%;"> Alliance: <i><b> {{ auth_char.alliance_name }}</b></i></span>
+                                        {% if auth_char.application.member_state == auth_char.application.MembershipStates.ACCEPTED%}
+                                        <span style="display:inline-block; min-width:5px"> </span>
+                                        <span class="whctools-good" style="font-size: 80%;"><i class="fa fas fa-circle-check"></i> WHC Member</span>
+                                        {% endif %}
+                                        <br>
+                                    {% if not auth_char.is_in_approved_corp %}
+                                        <span class="whctools-warning"><i class="fa fas fa-exclamation-triangle"></i>
+                                        {{ corp_requirements_message }}
+                                        </span>
                                     {% elif auth_char.is_shared %}
-                                    {% comment %} <p>{{ auth_char.rejected_reason }}</p>
-                                    <p>{{ auth_char.rejected_timeout }}</p> {% endcomment %}
                                         {% if auth_char.is_main or auth_char.is_main_member %}
                                             {% if auth_char.application.member_state == auth_char.application.MembershipStates.NOTAMEMBER%}
                                                 {% if auth_char.is_main %}
-                                                <p class="whctools-good"><i class="fa fas fa-exclamation-triangle"></i> Please check you have the required skills before applying or the application will be rejected and subject to a timeout!</p>
+                                                <div class="whctools-good"><i class="fa fas fa-exclamation-triangle"></i>Please check you have the required skills or you will be rejected and subject to a timeout before you can reapply.</div>
                                                 {% endif %}
                                                 <a href="/whctools/apply/{{auth_char.char_id}}" class="whcbutton btn btn-primary" role="button">Apply</a>
                                             {% endif %}
                                             {% if auth_char.application.member_state == auth_char.application.MembershipStates.APPLIED%}
-                                                <p class="whctools-good">You have applied and are awaiting approval!</p>
-                                                <p class="whctools-good">If you choose to withdraw the application you will be subject to a short timeout before you can reapply.</p>
+                                                <div class="whctools-good">Your application is awaiting approval.
+                                                If you choose to withdraw it, you will be subject to a short timeout before you can reapply.</div>
                                                 <a href="/whctools/withdraw/{{auth_char.char_id}}" class="whcbutton btn btn-warning" role="button">Withdraw</a>
                                             {% endif %}
                                             {% if auth_char.application.member_state == auth_char.application.MembershipStates.REJECTED%}
-                                                <p class="whctools-error"><i class="fa fas fa-exclamation-triangle"></i>You are currently under a timeout for: {{ auth_char.application.get_reject_reason_display }}</p>
-                                                <p class="whctools-error">You will be able to apply again in: {{auth_char.application.reject_timeout|timeuntil}}</p>
+                                                <div class="whctools-error"><i class="fa fas fa-exclamation-triangle"></i>You are currently under a timeout for: <b>{{ auth_char.application.get_reject_reason_display }}</b></div>
+                                                <div class="whctools-error">You will be able to apply again in: {{auth_char.application.reject_timeout|timeuntil}}</div>
                                             {% endif %}
                                             {% if auth_char.application.member_state == auth_char.application.MembershipStates.ACCEPTED%}
-                                            <p class="whctools-good">You are a member!</p>
                                             <a href="/whctools/withdraw/{{auth_char.char_id}}" class="whcbutton btn btn-warning" role="button">Leave</a>
                                             {% endif %}
                                         {% else %}
-                                        <p class="whctools-warning"><i class="fa fas fa-exclamation-triangle"></i>
-                                            Main character has not applied yet - please apply on Main first!
-                                        </p>
+                                        <div class="whctools-warning"><i class="fa fas fa-exclamation-triangle"></i>
+                                            Your Main character has not been accepted. Please apply on Main first.
+                                        </div>
                                         {% endif %}
                                     {% else %}
-                                    <p class="whctools-warning"><i class="fa fas fa-exclamation-triangle"></i>
-                                        This character has not been shared in Member Audit!
-                                    </p>
+                                    <div class="whctools-warning"><i class="fa fas fa-exclamation-triangle"></i>
+                                        This character has not been shared in Member Audit.
+                                    </div>
                                     {% endif %}
                                     </div>
                                 </div>
@@ -74,9 +78,9 @@
                                     </div>
                                     <div class="media-body">
                                     <h4 class="media-heading">{{unreg_char.char_name}}</h4>
-                                    <p class="whctools-error"><i class="fa fas fa-exclamation-triangle"></i>
-                                        This character has not been added to Member Audit!
-                                    </p>
+                                    <div class="whctools-error"><i class="fa fas fa-exclamation-triangle"></i>
+                                        This character has not been added to Member Audit.
+                                    </div>
                                     </div>
                                 </div>
                         {% endfor %}

--- a/whctools/utils.py
+++ b/whctools/utils.py
@@ -15,12 +15,25 @@ from memberaudit.tasks import update_character as ma_update_character
 #)
 
 from whctools import __title__
+from whctools.app_settings import ALLOWED_ALLIANCES
 from whctools.models import Acl, ACLHistory, ApplicationHistory, Applications
 
 from .aa3compat import get_all_related_characters_from_character
 from .app_settings import TRANSIENT_REJECT
 
 logger = LoggerAddTag(get_extension_logger(__name__), __title__)
+
+
+def is_character_in_allowed_corp(eve_character):
+    return (eve_character.alliance_id in ALLOWED_ALLIANCES)
+
+def get_corp_requirements_message():
+    """
+    Returns a human-readable string describing the corp criteria for an alt character.
+    """
+    # Since we can have arbitrarily complex conditions, it's useful to have a programmatically-defined descriptor.
+    # FIXME: sync with app_settings
+    return "Character must be in either the Ivy League or Ivy League Alt Alliance."
 
 
 def remove_character_from_community(app, new_state, reason, reject_time):

--- a/whctools/utils.py
+++ b/whctools/utils.py
@@ -6,6 +6,14 @@ from allianceauth.notifications import notify
 from allianceauth.services.hooks import get_extension_logger
 from app_utils.logging import LoggerAddTag
 
+from memberaudit.models import Character as MACharacter
+from memberaudit.tasks import update_character as ma_update_character
+# For MA 3.x, we have more granularity.
+#  update_character_skills as ma_update_character_skills,
+#  update_character_details as ma_update_character_details,
+#  update_character_corporation_history as ma_update_character_corporation_history,
+#)
+
 from whctools import __title__
 from whctools.models import Acl, ACLHistory, ApplicationHistory, Applications
 
@@ -193,3 +201,28 @@ def generate_raw_copy_for_acl(acl_characters: dict):
         output.append("----")
 
     return "\n".join(output)
+
+def force_update_memberaudit(eve_character):
+    logger.debug(f"Forcing memberaudit update for character {eve_character}")
+    try:
+        ma_char = MACharacter.objects.get(eve_character=eve_character)
+    except ObjectDoesNotExist:
+        ma_char = None
+    if ma_char is not None:
+        ma_char.reset_update_section("skills")
+        ma_char.reset_update_section("character_details")
+        ma_char.reset_update_section("corporation_history")
+        # For MA 3.x, there's more granularity in what to trigger
+        #for ma_update in (ma_update_character_skills,
+        #                  ma_update_character_details,
+        #                  ma_update_character_corporation_details):
+        #    ma_update.apply_async(
+        ma_update_character.apply_async(
+            kwargs={"character_pk": ma_char.pk, "force_update": True},
+            priority=3, # 0-255, 0 highest priority (MA uses 3/5/7)
+        )
+    else:
+        messages.warning(
+            request,
+            f"{eve_character.character_name} is not registered with Member Audit."
+        )

--- a/whctools/views_actions/player_actions.py
+++ b/whctools/views_actions/player_actions.py
@@ -8,6 +8,7 @@ from whctools import __title__
 from ..app_settings import TRANSIENT_REJECT
 from ..models import ACLHistory, Applications
 from ..utils import (
+    force_update_memberaudit,
     log_application_change,
     remove_character_from_acl,
     remove_character_from_community,
@@ -39,6 +40,9 @@ def submit_application(request, char_id):
     # Check if rejected
     if eve_char_application.member_state == Applications.MembershipStates.REJECTED:
         return "This character has been rejected previously and is still under cooldown for another application. Please contact WHC Community Coordinators on Discord"
+
+    # Queue up a forced memberaudit update
+    force_update_memberaudit(eve_char_application.eve_character)
 
     eve_char_application.member_state = Applications.MembershipStates.APPLIED
     eve_char_application.save()

--- a/whctools/views_actions/player_actions.py
+++ b/whctools/views_actions/player_actions.py
@@ -41,8 +41,14 @@ def submit_application(request, char_id):
     if eve_char_application.member_state == Applications.MembershipStates.REJECTED:
         return "This character has been rejected previously and is still under cooldown for another application. Please contact WHC Community Coordinators on Discord"
 
-    # Queue up a forced memberaudit update
-    force_update_memberaudit(eve_char_application.eve_character)
+    main_eve_char = eve_char_application.get_main_character()
+    if main_eve_char is None:
+        return "This character has no Auth profile, which should not be possible. Please contact @webservices on discord."
+    main_char_application = main_eve_char.applications
+
+    # If this is a new main application, queue up a forced memberaudit update
+    if eve_char_application == main_char_application:
+        force_update_memberaudit(eve_char_application.eve_character)
 
     eve_char_application.member_state = Applications.MembershipStates.APPLIED
     eve_char_application.save()

--- a/whctools/views_actions/player_actions.py
+++ b/whctools/views_actions/player_actions.py
@@ -9,6 +9,7 @@ from ..app_settings import TRANSIENT_REJECT
 from ..models import ACLHistory, Applications
 from ..utils import (
     force_update_memberaudit,
+    is_character_in_allowed_corp,
     log_application_change,
     remove_character_from_acl,
     remove_character_from_community,
@@ -41,13 +42,16 @@ def submit_application(request, char_id):
     if eve_char_application.member_state == Applications.MembershipStates.REJECTED:
         return "This character has been rejected previously and is still under cooldown for another application. Please contact WHC Community Coordinators on Discord"
 
+    # Check if character is in a valid corp/alliance
+    if not is_character_in_allowed_corp(eve_char_application.eve_character):
+        logger.debug(f"Character {eve_char_application} applied but is in an invalid corp.")
+        return "This character isn't in an approved corp/alliance."
+
+    # If this is a new main application, queue up a forced memberaudit update
     main_eve_char = eve_char_application.get_main_character()
     if main_eve_char is None:
         return "This character has no Auth profile, which should not be possible. Please contact @webservices on discord."
-    main_char_application = main_eve_char.applications
-
-    # If this is a new main application, queue up a forced memberaudit update
-    if eve_char_application == main_char_application:
+    if eve_char_application == main_eve_char.applications:
         force_update_memberaudit(eve_char_application.eve_character)
 
     eve_char_application.member_state = Applications.MembershipStates.APPLIED


### PR DESCRIPTION
When a member applies, a memberaudit update is immediately queued for that character. Unless a staff member looks at the application within seconds of that action, this more or less solves the stale skill issue.

Because we're running MA 2.10, this is still a bit heavy-handed, since we run a *full* character update every time, instead of just pulling skills and corp/alliance. That can be easily fixed if MA is updated.

Fixes #17.