### PR TITLE
Change user 'Leave' button to danger.

### DIFF
--- a/whctools/templates/whctools/index.html
+++ b/whctools/templates/whctools/index.html
@@ -50,7 +50,7 @@
                                             {% endif %}
                                             {% if auth_char.application.member_state == auth_char.application.MembershipStates.ACCEPTED%}
                                             <p class="whctools-good">You are a member!</p>
-                                            <a href="/whctools/withdraw/{{auth_char.char_id}}" class="whcbutton btn btn-warning" role="button">Leave</a>
+                                            <a href="/whctools/withdraw/{{auth_char.char_id}}" class="whcbutton btn btn-danger" role="button">Leave</a>
                                             {% endif %}
                                         {% else %}
                                         <p class="whctools-warning"><i class="fa fas fa-exclamation-triangle"></i>


### PR DESCRIPTION
When looking at a list of characters, an accepted main and a bunch of pending alts look identical. Easy to confuse the two and accidentally remove a character from WHC, causing problems.


This is a trivially simple fix, but I didn't want to shove it in sideways with another PR.