### PR TITLE
Add MA skill age checks

### DIFF
--- a/whctools/app_settings.py
+++ b/whctools/app_settings.py
@@ -13,3 +13,7 @@ LARGE_REJECT = getattr(settings, "WHCTOOLS_LARGE_REJECT", 365)
 LIMIT_TO_ALLIANCES = getattr(settings, "WHCTOOLS_LIMIT_TO_ALLIANCES", False)
 
 ALLOWED_ALLIANCES = getattr(settings, "WHCTOOLS_ALLIANCES", [937872513, 99010193])
+
+# The maximum amount of time we're willing to believe an ESI
+# task scheduled with Celery will run before admiting it failed.
+ESI_TASK_TIMEOUT_SECONDS = getattr(settings, "ESI_TASK_TIMEOUT_SECONDS", 3600)

--- a/whctools/templates/whctools/base_staff.html
+++ b/whctools/templates/whctools/base_staff.html
@@ -59,25 +59,28 @@ document.addEventListener('DOMContentLoaded', function() {
             success: function(data) {
                 console.log('Received data:', data); // Log the received data
 
-                if (data.skill_sets) {
+                if (data.alt_data) {
                     // Build the popup content with the data
                     var content = '<h3>Skill Set Checks for <u>' + data.applying_character + '</u> related characters</h3>';
-                    content += '<table class="table"><tr class="whctools-tr"><th>Character Name</th>';
+                    content += '<table class="table"><tr class="whctools-tr"><th>Character Name</th><th>Skills Updated</th>';
 
                     // Get the keys from the first skill set to create the table headers
-                    var firstKey = Object.keys(data.skill_sets)[0];
-                    if (firstKey) {
-                        var skillKeys = Object.keys(data.skill_sets[firstKey]);
-                        skillKeys.forEach(function(skill) {
-                            content += '<th>' + skill + '</th>';
+                    var firstAlt = Object.keys(data.alt_data)[0]
+                    if (firstAlt) {
+                        var skillKeys = Object.keys(data.alt_data[firstAlt][1]);
+                        skillKeys.forEach(function(skillset) {
+                            content += '<th>' + skillset + '</th>';
                         });
                     }
 
                     content += '</tr>';
-                    $.each(data.skill_sets, function(alt_name, skill_sets) {
+                    $.each(data.alt_data, function(alt_name, alt_data) {
+                        last_update = alt_data[0]
+                        skill_sets = alt_data[1]
                         content += '<tr><td>' + alt_name + '</td>';
-                        $.each(skill_sets, function(skill_name, skill_check) {
-                            content += '<td style="text-align: center;"><i class="' + (skill_check ? 'fas fa-check' : 'fas fa-times') + '" style="color: ' + (skill_check ? 'green' : 'red') + ';"></i></td>';
+                        content += '<td>' + last_update + '</td>';
+                        $.each(skill_sets, function(skillset__name, skillset_check) {
+                            content += '<td style="text-align: center;"><i class="' + (skillset_check ? 'fas fa-check' : 'fas fa-times') + '" style="color: ' + (skillset_check ? 'green' : 'red') + ';"></i></td>';
                         });
                         content += '</tr>';
                     });

--- a/whctools/templates/whctools/index.html
+++ b/whctools/templates/whctools/index.html
@@ -55,7 +55,6 @@
                                             {% endif %}
                                             {% if auth_char.application.member_state == auth_char.application.MembershipStates.ACCEPTED%}
 
-                                            <p class="whctools-good">You are a member!</p>
                                             <a href="/whctools/withdraw/{{auth_char.char_id}}" class="whcbutton btn btn-danger" role="button">Leave</a>
 
                                             {% endif %}

--- a/whctools/templates/whctools/staff/staff_apps_in_progress.html
+++ b/whctools/templates/whctools/staff/staff_apps_in_progress.html
@@ -23,7 +23,11 @@
             </td>
             <td>{{ char.application.last_updated|timesince }}</td>
             <td>
+                {% if char.is_main_char and not char.ma_is_valid %}
+                <div class="whctools-error"><i class="fa fas fa-exclamation-triangle"></i> Failed to fetch skills from Member Audit.<br>Refresh page or ask player to re-register if it persists.</div>
+                {% else %}
                 <button class="whcbutton btn btn-primary openSkillcheckPopup" data-character-id="{{ char.application.eve_character_id }}">Check Skills</button>
+                {% endif %}
             </td>
             <td>
                 <select class="acl-dropdown" data-character-id="{{ char.application.eve_character.id }}">

--- a/whctools/utils.py
+++ b/whctools/utils.py
@@ -10,20 +10,26 @@ from memberaudit.models import Character as MACharacter
 #from memberaudit.tasks import update_character as ma_update_character
 # For MA 3.x, we have more granularity.
 from memberaudit.tasks import update_character_skills as ma_update_character_skills
-#  update_character_details as ma_update_character_details,
-#  update_character_corporation_history as ma_update_character_corporation_history,
-#)
 
 from whctools import __title__
 from whctools.app_settings import ALLOWED_ALLIANCES
 from whctools.models import Acl, ACLHistory, ApplicationHistory, Applications
 
 from .aa3compat import get_all_related_characters_from_character
-from allianceauth.framework.api.evecharacter import get_user_from_evecharacter
+from allianceauth.framework.api.evecharacter import (
+    get_user_from_evecharacter,
+    get_main_character_from_evecharacter,
+)
 from .app_settings import TRANSIENT_REJECT
 
 logger = LoggerAddTag(get_extension_logger(__name__), __title__)
 
+
+def is_main_eve_character(eve_character):
+    main_character = get_main_character_from_evecharacter(eve_character)
+    if (main_character is not None) and (main_character == eve_character):
+        return True
+    return False
 
 def is_character_in_allowed_corp(eve_character):
     return (eve_character.alliance_id in ALLOWED_ALLIANCES)
@@ -265,3 +271,21 @@ def force_update_memberaudit(eve_character):
             request,
             f"{eve_character.character_name} is not registered with Member Audit."
         )
+
+def get_last_ma_update_time(eve_character):
+    '''Return a datetime for when memberaudit was last successfully updated with skill data'''
+
+    logger.info(f"get_last_ma_update_time")
+    try:
+        ma_char = eve_character.memberaudit_character
+        # Also check it wasn't an error last time
+        is_status_okay = ma_char.is_update_status_ok()
+        last_ma_update = ma_char.update_status_set.get(
+            section=MACharacter.UpdateSection.SKILLS
+        ).update_finished_at
+        if is_status_okay:
+            return last_ma_update
+    except Exception as e:
+        pass
+    # If something goes wrong, return an unreasonably old datetime.
+    return datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)

--- a/whctools/utils.py
+++ b/whctools/utils.py
@@ -7,9 +7,9 @@ from allianceauth.services.hooks import get_extension_logger
 from app_utils.logging import LoggerAddTag
 
 from memberaudit.models import Character as MACharacter
-from memberaudit.tasks import update_character as ma_update_character
+#from memberaudit.tasks import update_character as ma_update_character
 # For MA 3.x, we have more granularity.
-#  update_character_skills as ma_update_character_skills,
+from memberaudit.tasks import update_character_skills as ma_update_character_skills
 #  update_character_details as ma_update_character_details,
 #  update_character_corporation_history as ma_update_character_corporation_history,
 #)
@@ -257,17 +257,9 @@ def force_update_memberaudit(eve_character):
         ma_char = None
     if ma_char is not None:
         ma_char.reset_update_section("skills")
-        ma_char.reset_update_section("character_details")
-        ma_char.reset_update_section("corporation_history")
-        # For MA 3.x, there's more granularity in what to trigger
-        #for ma_update in (ma_update_character_skills,
-        #                  ma_update_character_details,
-        #                  ma_update_character_corporation_details):
-        #    ma_update.apply_async(
-        ma_update_character.apply_async(
+        ma_update_character_skills.apply_async(
             kwargs={"character_pk": ma_char.pk, "force_update": True},
-            priority=3, # 0-255, 0 highest priority (MA uses 3/5/7)
-        )
+            priority=3)
     else:
         messages.warning(
             request,


### PR DESCRIPTION
Due to token issues, it's possible for skill checks to be stale
even after we force-update them. This adds two features to deal
with that:
- First, we ensure that on main applications, if the MA skills
  are stale, we flag a warning and disallow a skill check. It's
  entirely possible that the character already met the skill
  requirements in the past, but this enforces a non-stale MA.
- Second, we add the date of the last known valid skill update
  for all alts in the skill check panel. Since we don't force-
  update alt skills, staff may like to know if the skills are
  wildly out of date.

Adds a new application setting ESI_TASK_TIMEOUT_SECONDS which
governs whether we believe we've allowed sufficient time for
a celery task to complete. In general, this should happen
within seconds, but the idea is to ensure that a race condition
doesn't accidentally cause a staff member to believe stale
skills are actually valid.

Also took the opportunity to reduce the scope on the force-update
we do every application. It now only asks for a skill update.