### PR TITLE
Fix ACL view for characters without mains

### DIFF
--- a/whctools/templates/whctools/base.html
+++ b/whctools/templates/whctools/base.html
@@ -138,6 +138,13 @@
         background-color: rgb(64,69,75);
     }
 
+    .whctools-error-row {
+        background-color: rgb(213, 67, 62);
+    }
+    .whctools-error-row:hover {
+        background-color: rgb(217, 83, 79);
+    }
+
     /* The modal (background) */
     .whctools-modal {
         display: none; /* Hidden by default */

--- a/whctools/templates/whctools/list_acl_members.html
+++ b/whctools/templates/whctools/list_acl_members.html
@@ -47,6 +47,17 @@
                             </tr>
                         </thead>
                         <tbody>
+                            {% for orphan in orphans %}
+                            <tr class="whctools-main-row whctools-error-row" data-member-id="">
+                                <td></td>
+                                <td><img src="{{ orphan.portrait_url }}" alt="{{ orphan.character_name }}"></td>
+                                <td>{{orphan.character_name}}</td>
+                                <td><b>No main found</b></td>
+                                <td>{{orphan.corporation_name}}</td>
+                                <td>{{orphan.alliance_name}}</td>
+                                <td><a href="/whctools/staff/action/{{orphan.character_id}}/reject/other/{{reject_timers.medium_reject}}/acl" class="whcbutton btn btn-warning" role="button" id="remove-alt">Remove Character</a></td>
+                            </tr>
+                            {% endfor %}
                             {% for member in members %}
                             <tr class="whctools-main-row" data-member-id="{{ member.main.character_id }}">
                                 {% with member.alts|length as alts_length %}


### PR DESCRIPTION
Adds a new sub-group of members internally called "orphans" which represents characters without a valid main (not characters with an out-of-corp main). When AA can't retrieve a main, it returns a sentinel value which it assumes is a deleted character. We check this now and correctly flag these as needing attention.

Fixes #63.