### PR TITLE
Enable Auth group sync.

### DIFF
--- a/whctools/templates/whctools/list_acl_members.html
+++ b/whctools/templates/whctools/list_acl_members.html
@@ -28,11 +28,9 @@
                             </div>
                             <div class="pull-right">
                                 <button id="copyAclListButton" class="btn btn-primary whcbutton">Copy ACL as text</button>
-                                {% comment %}
                                 <a id="syncAclGroups" class="btn btn-primary whcbutton" href="/whctools/staff/{{ acl_name }}/sync_groups_with_acl">
                                     Sync Auth groups with this ACL
                                 </a>
-                                {% endcomment %}
                             </div>
                     </div>
                     <table class="table table-hover whctools-table whctools-table-staff">


### PR DESCRIPTION
This functionality already existed but was disabled to prevent mistakes.