### PR TITLE
Enable Wanderer ACL integration.

### DIFF
--- a/whctools/templates/whctools/list_acl_members.html
+++ b/whctools/templates/whctools/list_acl_members.html
@@ -31,6 +31,9 @@
                                 <a id="syncAclGroups" class="btn btn-primary whcbutton" href="/whctools/staff/{{ acl_name }}/sync_groups_with_acl">
                                     Sync Auth groups with this ACL
                                 </a>
+                                <a id="syncAclWanderer" class="btn btn-primary whcbutton" href="/whctools/staff/{{ acl_name }}/sync_wanderer_with_acl">
+                                    Sync Wanderer with this ACL
+                                </a>
                             </div>
                     </div>
                     <table class="table table-hover whctools-table whctools-table-staff">

--- a/whctools/urls.py
+++ b/whctools/urls.py
@@ -30,5 +30,6 @@ urlpatterns = [
     ),
     #path("staff/list_acls", views.list_acls, name="staff_view_acl_lists"),
     path("staff/getSkills/<char_id>", views.get_skills, name="get_skills"),
-    path("staff/<acl_pk>/sync_groups_with_acl", views.sync_groups_with_acl, name="sync_groups_with_acl")
+    path("staff/<acl_pk>/sync_groups_with_acl", views.sync_groups_with_acl, name="sync_groups_with_acl"),
+    path("staff/<acl_pk>/sync_wanderer_with_acl", views.sync_wanderer_with_acl, name="sync_wanderer_with_acl"),
 ]


### PR DESCRIPTION
Automatically add characters to a Wanderer ACL whenever they are accepted to an ACL in Auth.
Automatically remove characters from a Wanderer ACL whenever they are removed from an ACL in Auth.
Provide a button to manually sync up Wanderer and Auth.

Add environment variables:
  WANDERER_ACL_ID - The UUID of the Wanderer ACL (not the map UUID)
  WANDERER_ACL_TOKEN - The Wanderer ACL API key (not the map key)

Fixes #81.